### PR TITLE
New flint based temporal joiner plugin [CDAP-15910]

### DIFF
--- a/flint-plugins/docs/File-streamingsource.md
+++ b/flint-plugins/docs/File-streamingsource.md
@@ -1,0 +1,57 @@
+# File Streaming Source
+
+
+Description
+-----------
+File streaming source. Watches a directory and streams file contents of any new files added to the directory.
+Files must be atomically moved or renamed.
+
+
+Use Case
+--------
+This source is used whenever you want to read files from a directory in a streaming context.
+For example, you may want to read access logs as they are moved into an archive directory.
+
+
+Properties
+----------
+**referenceName:** This will be used to uniquely identify this source for lineage, annotating metadata, etc.
+
+**path:** The path of the directory to monitor. Files must be written to the monitored directory by
+"moving" them from another location within the same file system. File names starting with . are ignored. (Macro-enabled)
+
+**format:** Format of files in the directory. Supported formats are 'text', 'csv', 'tsv', 'clf', 'grok', and 'syslog'.
+The default format is 'text'. (Macro-enabled)
+
+**schema:** Schema of files in the directory.
+
+**extensions:** Comma separated list of file extensions to accept. If not specified, all files in the directory
+will be read. Otherwise, only files with an extension in this list will be read. (Macro-enabled)
+
+**ignoreThreshold:** Ignore files that are older than this many seconds. Defaults to 60. (Macro-enabled)
+
+
+Example
+-------
+This example reads from the '/data/events' directory on an hdfs cluster whose namenode
+is running on namenode.example.com. The source will monitor the directory for any
+new files that are added. It will parse those files as comma separated files with three
+columns: timestamp, user, and action.
+
+    {
+        "name": "File",
+        "type": "streamingsource",
+        "properties": {
+            "path": "hdfs://namenode.example.com/data/events",
+            "format": "csv",
+            "schema": "{
+                \"type\":\"record\",
+                \"name\":\"event\",
+                \"fields\":[
+                    {\"name\":\"timestamp\",\"type\":\"long\"},
+                    {\"name\":\"user\",\"type\":\"string\"},
+                    {\"name\":\"action\",\"type\":\"string\"}
+                ]
+            }"
+        }
+    }

--- a/flint-plugins/docs/HTTPPoller-streamingsource.md
+++ b/flint-plugins/docs/HTTPPoller-streamingsource.md
@@ -1,0 +1,61 @@
+# HTTP Poller Streaming Source
+
+Description
+-----------
+This is a streaming source that will fetch data from a specified URL at a given interval and
+pass the results to the next plugin. This source will return one record for each request to
+the specified URL. The record will contain a timestamp, the URL that was requested, the response code
+of the response and the set of response headers in a map<string, string> format, and the body of the response.
+
+Use Case
+--------
+The source is used whenever you need to fetch data from a URL at a regular interval. It could be
+used to fetch Atom or RSS feeds regularly, or to fetch the status of an external system.
+
+
+Properties
+----------
+**referenceName:** This will be used to uniquely identify this source for lineage, annotating metadata, etc.
+
+**url:** Required The URL to fetch data from.
+
+**interval:** Required The time to wait between fetching data from the URL in seconds.
+
+**requestHeaders:** An optional string of header values to send in each request where the keys and values are
+delimited by a colon (":") and each pair is delimited by a newline ("\n").
+
+**charset:** The charset of the content returned by the URL. Defaults to UTF-8.
+
+**followRedirects:** Whether to automatically follow redirects. Defaults to true.
+
+**connectTimeout:** The time in milliseconds to wait for a connection. Set to 0 for infinite. Defaults to 60000 (1 minute).
+
+**readTimeout:** The time in milliseconds to wait for a read. Set to 0 for infinite. Defaults to 60000 (1 minute).
+
+Example
+-------
+This example fetches data from a URL every hour using a custom user agent:
+
+    {
+        "name": "HTTPPoller",
+        "type": "streamingsource",
+        "properties": {
+            "url": "http://example.com/sampleEndpoint",
+            "interval": "60",
+            "requestHeaders": "User-Agent:HydratorPipeline\nAccept:application/json"
+        }
+    }
+
+The contents will output records with this schema:
+
+    +======================================+
+    | field name     | type                |
+    +======================================+
+    | ts             | long                |
+    | url            | string              |
+    | responseCode   | int                 |
+    | headers        | map<string, string> |
+    | body           | string              |
+    +======================================+
+
+All fields will be always be included, but the body might be an empty string.

--- a/flint-plugins/docs/Twitter-streamingsource.md
+++ b/flint-plugins/docs/Twitter-streamingsource.md
@@ -1,0 +1,65 @@
+# Twitter Streaming Source
+
+
+Description
+-----------
+Samples tweets in real-time through Spark streaming. Output records will have this schema:
+
+    +================================+
+    | field name  | type             |
+    +================================+
+    | id          | long             |
+    | message     | string           |
+    | lang        | nullable string  |
+    | time        | nullable long    |
+    | favCount    | int              |
+    | rtCount     | int              |
+    | source      | nullable string  |
+    | geoLat      | nullable double  |
+    | geoLong     | nullable double  |
+    | isRetweet   | boolean          |
+    +================================+
+
+
+Use Case
+--------
+The source is used whenever you want to sample tweets from Twitter in real-time using Spark streaming.
+For example, you may want to read tweets and store them in a table where they can
+be accessed by your data scientists to perform experiments.
+
+
+Properties
+----------
+**referenceName:** This will be used to uniquely identify this source for lineage, annotating metadata, etc.
+
+See the [Twitter OAuth documentation] for more information on obtaining
+your access token and access token secret. The consumer key and secret
+are specific to your Twitter app. Login, view [your apps], then click on
+the relevant app to find the consumer key and secret.
+
+  [Twitter OAuth documentation]: https://dev.twitter.com/oauth/overview
+  [your apps]: https://apps.twitter.com/
+
+**ConsumerKey:** Twitter Consumer Key.
+
+**ConsumerSecret:** Twitter Consumer Secret.
+
+**AccessToken:** Twitter Access Token.
+
+**AccessTokenSecret:** Twitter Access Token Secret.
+
+
+Example
+-------
+
+    {
+        "name": "Twitter",
+        "type": "streamingsource",
+        "properties": {
+            "AccessToken": "GetAccessTokenFromTwitter",
+            "AccessTokenSecret": "GetAccessTokenSecretFromTwitter",
+            "ConsumerKey": "GetConsumerKeyFromTwitter",
+            "ConsumerSecret": "GetConsumerSecretFromTwitter"
+        }
+    }
+

--- a/flint-plugins/pom.xml
+++ b/flint-plugins/pom.xml
@@ -1,0 +1,261 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  Copyright © 2015 Cask Data, Inc.
+
+  Licensed under the Apache License, Version 2.0 (the "License"); you may not
+  use this file except in compliance with the License. You may obtain a copy of
+  the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+  WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+  License for the specific language governing permissions and limitations under
+  the License.
+  -->
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <parent>
+    <artifactId>hydrator-plugins</artifactId>
+    <groupId>co.cask.hydrator</groupId>
+    <version>2.1.1-SNAPSHOT_5.1.215</version>
+  </parent>
+
+  <properties>
+    <spark.version>2.3.0</spark.version>
+  </properties>
+
+  <name>Flint Plugins</name>
+  <artifactId>flint-plugins</artifactId>
+  <modelVersion>4.0.0</modelVersion>
+
+  <repositories>
+    <repository>
+      <id>cloudera</id>
+      <url>https://repository.cloudera.com/artifactory/cloudera-repos/</url>
+    </repository>
+  </repositories>
+
+  <dependencies>
+    <dependency>
+      <groupId>co.cask.cdap</groupId>
+      <artifactId>cdap-api-spark</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>co.cask.cdap</groupId>
+      <artifactId>cdap-etl-api</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>co.cask.cdap</groupId>
+      <artifactId>cdap-etl-api-spark</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>co.cask.cdap</groupId>
+      <artifactId>cdap-data-pipeline</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>co.cask.cdap</groupId>
+      <artifactId>cdap-data-streams</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>io.netty</groupId>
+      <artifactId>netty-all</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>co.cask.http</groupId>
+      <artifactId>netty-http</artifactId>
+    </dependency>
+<!--    <dependency>
+      <groupId>co.cask.cdap</groupId>
+      <artifactId>hydrator-test</artifactId>
+    </dependency>-->
+    <dependency>
+      <groupId>co.cask.hydrator</groupId>
+      <artifactId>hydrator-common</artifactId>
+      <version>${project.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>co.cask.cdap</groupId>
+      <artifactId>cdap-formats</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>com.google.guava</groupId>
+      <artifactId>guava</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.spark</groupId>
+      <artifactId>spark-core_2.11</artifactId>
+      <version>${spark.version}</version>
+      <scope>provided</scope>
+      <exclusions>
+        <!-- excludes scala-compiler and scala-reflect to avoid conflicting with the one from spark-repl -->
+        <exclusion>
+          <groupId>org.scala-lang</groupId>
+          <artifactId>scala-compiler</artifactId>
+        </exclusion>
+        <exclusion>
+          <groupId>org.scala-lang</groupId>
+          <artifactId>scala-reflect</artifactId>
+        </exclusion>
+        <exclusion>
+          <groupId>org.slf4j</groupId>
+          <artifactId>slf4j-log4j12</artifactId>
+        </exclusion>
+        <exclusion>
+          <groupId>log4j</groupId>
+          <artifactId>log4j</artifactId>
+        </exclusion>
+        <exclusion>
+          <groupId>org.apache.hadoop</groupId>
+          <artifactId>hadoop-client</artifactId>
+        </exclusion>
+        <exclusion>
+          <groupId>com.esotericsoftware.reflectasm</groupId>
+          <artifactId>reflectasm</artifactId>
+        </exclusion>
+        <exclusion>
+          <groupId>org.apache.curator</groupId>
+          <artifactId>curator-recipes</artifactId>
+        </exclusion>
+        <exclusion>
+          <groupId>org.tachyonproject</groupId>
+          <artifactId>tachyon-client</artifactId>
+        </exclusion>
+        <exclusion>
+          <groupId>org.scala-lang</groupId>
+          <artifactId>scala-compiler</artifactId>
+        </exclusion>
+        <exclusion>
+          <groupId>org.eclipse.jetty.orbit</groupId>
+          <artifactId>javax.servlet</artifactId>
+        </exclusion>
+        <!--
+          Need to exclude this since Spark brings in an older version that makes
+          S3 not work in standalone. This doesn't affect distributed mode.
+        -->
+        <exclusion>
+          <groupId>net.java.dev.jets3t</groupId>
+          <artifactId>jets3t</artifactId>
+        </exclusion>
+      </exclusions>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.spark</groupId>
+      <artifactId>spark-mllib_2.11</artifactId>
+      <version>${spark.version}</version>
+      <scope>provided</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.spark</groupId>
+      <artifactId>spark-streaming_2.11</artifactId>
+      <version>${spark.version}</version>
+      <scope>provided</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.spark</groupId>
+      <artifactId>spark-repl_2.11</artifactId>
+      <version>${spark.version}</version>
+      <scope>provided</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.hadoop</groupId>
+      <artifactId>hadoop-common</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.twitter4j</groupId>
+      <artifactId>twitter4j-core</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.twitter4j</groupId>
+      <artifactId>twitter4j-stream</artifactId>
+    </dependency>
+
+    <dependency>
+      <groupId>commons-lang</groupId>
+      <artifactId>commons-lang</artifactId>
+      <version>2.6</version>
+    </dependency>
+
+
+    <!-- https://mvnrepository.com/artifact/com.twosigma/flint -->
+    <dependency>
+      <groupId>com.twosigma</groupId>
+      <artifactId>flint</artifactId>
+      <version>0.6.0</version>
+    </dependency>
+
+  </dependencies>
+
+  <build>
+    <plugins>
+
+      <plugin>
+        <groupId>net.alchim31.maven</groupId>
+        <artifactId>scala-maven-plugin</artifactId>
+        <version>3.3.1</version>
+        <configuration>
+          <args>
+            <arg>-target:jvm-1.7</arg>
+          </args>
+        </configuration>
+        <executions>
+          <execution>
+            <id>scala-add-source</id>
+            <goals>
+              <goal>add-source</goal>
+            </goals>
+          </execution>
+          <execution>
+            <id>scala-compile</id>
+            <!-- Needs to be before the compile phase -->
+            <phase>process-resources</phase>
+            <goals>
+              <goal>compile</goal>
+            </goals>
+          </execution>
+          <execution>
+            <id>scala-test-compile</id>
+            <!-- Needs to be before the test-compile phase -->
+            <phase>process-test-resources</phase>
+            <goals>
+              <goal>testCompile</goal>
+            </goals>
+          </execution>
+        </executions>
+      </plugin>
+
+      <plugin>
+        <groupId>org.apache.felix</groupId>
+        <artifactId>maven-bundle-plugin</artifactId>
+        <version>3.3.0</version>
+        <extensions>true</extensions>
+        <configuration>
+          <instructions>
+            <_exportcontents>
+              co.cask.hydrator.plugin.flint.*;
+              com.twosigma.flint.*;
+              org.apache.spark.sql;
+            </_exportcontents>
+            <Embed-Dependency>*;inline=false;scope=compile</Embed-Dependency>
+            <Embed-Transitive>true</Embed-Transitive>
+            <Embed-Directory>lib</Embed-Directory>
+          </instructions>
+        </configuration>
+        <executions>
+          <execution>
+            <phase>package</phase>
+            <goals>
+              <goal>bundle</goal>
+            </goals>
+          </execution>
+        </executions>
+      </plugin>
+      <plugin>
+        <groupId>co.cask</groupId>
+        <artifactId>cdap-maven-plugin</artifactId>
+      </plugin>
+    </plugins>
+  </build>
+</project>

--- a/flint-plugins/src/main/java/co/cask/hydrator/plugin/flint/TemporalJoiner.java
+++ b/flint-plugins/src/main/java/co/cask/hydrator/plugin/flint/TemporalJoiner.java
@@ -1,0 +1,776 @@
+package co.cask.hydrator.plugin.flint;
+
+import co.cask.cdap.api.annotation.Description;
+import co.cask.cdap.api.annotation.Name;
+import co.cask.cdap.api.annotation.Plugin;
+import co.cask.cdap.api.data.format.StructuredRecord;
+import co.cask.cdap.api.data.schema.Schema;
+import co.cask.cdap.etl.api.MultiInputPipelineConfigurer;
+import co.cask.cdap.etl.api.MultiInputStageConfigurer;
+import co.cask.cdap.etl.api.batch.BatchJoinerContext;
+import co.cask.cdap.etl.api.batch.SparkExecutionPluginContext;
+import co.cask.cdap.etl.api.batch.SparkJoiner;
+import co.cask.cdap.etl.api.lineage.field.FieldOperation;
+import co.cask.cdap.etl.api.lineage.field.FieldTransformOperation;
+import com.google.common.annotations.VisibleForTesting;
+import com.google.common.base.Preconditions;
+import com.google.common.collect.ArrayListMultimap;
+import com.google.common.collect.Multimap;
+import com.google.common.collect.Table;
+import com.twosigma.flint.timeseries.TimeSeriesRDD;
+import org.apache.commons.lang.StringUtils;
+import org.apache.spark.api.java.JavaRDD;
+import org.apache.spark.api.java.function.Function;
+import org.apache.spark.sql.Row;
+import org.apache.spark.sql.Row$;
+import org.apache.spark.sql.catalyst.expressions.GenericRowWithSchema;
+import org.apache.spark.sql.types.*;
+import org.apache.spark.storage.StorageLevel;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import scala.collection.JavaConverters;
+import scala.collection.Seq;
+import scala.concurrent.duration.Duration;
+
+import javax.ws.rs.Path;
+import java.io.Externalizable;
+import java.io.IOException;
+import java.io.ObjectInput;
+import java.io.ObjectOutput;
+import java.util.*;
+import java.util.concurrent.TimeUnit;
+
+@Plugin(type = SparkJoiner.PLUGIN_TYPE)
+@Name("TemporalJoiner")
+@Description("Perform temporal left outer join operation on records from exactly two input stages. " +
+    "Bot input stages are expected to have a time field on which the temporal part of the join " +
+    "will be executed with unexact match semantic: for each record on the left part of the join, " +
+    "the most recent previous record of the right part of the join will be merged if the duration between both records " +
+    "falls behind a given tolerance 'e.g. 10 minutes). Optionnaly, other join keys with exact match semantic may also" +
+    "be provided, so that only the most recent record on the right side that can be joined via exact match will be considered ")
+public class TemporalJoiner extends SparkJoiner<StructuredRecord> {
+
+  private static Logger log = LoggerFactory.getLogger(TemporalJoiner.class);
+
+  public static final String JOIN_OPERATION_DESCRIPTION = "Used as a key in a join";
+  public static final String TEMPORAL_JOIN_OPERATION_DESCRIPTION = "Used as a key in a temporal join";
+  public static final String IDENTITY_OPERATION_DESCRIPTION = "Unchanged as part of a join";
+  public static final String RENAME_OPERATION_DESCRIPTION = "Renamed as a part of a join";
+
+  public static final String TIMEFIELD_ALIAS = "$$time$$";
+  public static final String JOIN_KEY_ALIAS = "$$key$$";
+  private final TemporalJoinerConfig conf;
+
+  public TemporalJoiner(TemporalJoinerConfig conf) {
+    this.conf = conf;
+  }
+
+  private Map<String, Schema> inputSchemas;
+  private Schema outputSchema;
+  private Map<String, List<String>> perStageJoinKeys;
+  private Table<String, String, String> perStageSelectedFields;
+  private Multimap<String, String> duplicateFields = ArrayListMultimap.create();
+
+
+  @Override
+  public void initialize(SparkExecutionPluginContext context) throws Exception {
+    log.debug("initializing TemporalJoiner");
+    init(context.getInputSchemas());
+    inputSchemas = context.getInputSchemas();
+    outputSchema = context.getOutputSchema();
+  }
+
+  private void init(Map<String, Schema> inputSchemas) {
+    validateTemporalFields(inputSchemas, conf);
+    validateJoinKeySchemas(inputSchemas, conf.getPerStageJoinKeys());
+    validateFieldNames(inputSchemas);
+    validateTolerance(conf.getTolerance());
+    perStageSelectedFields = conf.getPerStageSelectedFields();
+  }
+
+  private void validateFieldNames(Map<String, Schema> inputSchemas) throws IllegalArgumentException {
+    for (Schema schema : inputSchemas.values()) {
+
+      schema.getFields().forEach(field -> {
+        if (field.getName().startsWith("$")) {
+          throw new IllegalArgumentException(String.format("Field '%s' is starting with character '$' which is not allowed",
+              field.getName()));
+        }
+      });
+    }
+  }
+
+  private void validateTolerance(String tolerance) throws IllegalArgumentException{
+    try {
+      Duration.apply(tolerance);
+    } catch (NumberFormatException e) {
+      throw new IllegalArgumentException(String.format("Illegal tolerance : %s", tolerance), e);
+    }
+  }
+
+  private void validateTemporalFields(Map<String, Schema> inputSchemas, TemporalJoinerConfig conf) throws  IllegalArgumentException{
+
+    if (inputSchemas.size() != 2) {
+      throw new IllegalArgumentException(String.format("Found %s inputs, exactly 2 is required ", inputSchemas.size()));
+    }
+
+    Schema leftSchema = null;
+    Schema rightSchema = null;
+    for (Map.Entry<String, Schema> entry : inputSchemas.entrySet()) {
+      if (entry.getKey().equals(conf.leftInput)) {
+        leftSchema = entry.getValue();
+      } else {
+        rightSchema = entry.getValue();
+      }
+    }
+    assert leftSchema != null && rightSchema != null;
+
+    validateTimeField(conf.getTimeFieldLeft(), leftSchema);
+    validateTimeField(conf.getTimeFieldRight(), rightSchema);
+
+  }
+
+  private void validateTimeField(String timeFieldName, Schema schema) throws IllegalArgumentException{
+    Schema.Field timeField = schema.getField(timeFieldName);
+    if (timeField == null) {
+      throw new IllegalArgumentException(String.format("Unknown time field %s for left stage", timeFieldName));
+    }
+    if (!(timeField.getSchema().getType() == Schema.Type.LONG || timeField.getSchema().getType() == Schema.Type.INT)) {
+      throw new IllegalArgumentException(String.format("Expected integer type for field %s. Found %s", timeFieldName, timeField.getSchema().getType()));
+    }
+  }
+
+  void validateJoinKeySchemas(Map<String, Schema> inputSchemas, Map<String, List<String>> joinKeys) {
+    perStageJoinKeys = joinKeys;
+
+    if (perStageJoinKeys.isEmpty()) {
+      // that's ok, no exact match join key found which is ok
+      return;
+    }
+
+    // otherway, there must be exactly one key foe each stage
+    if (perStageJoinKeys.size() != inputSchemas.size()) {
+      throw new IllegalArgumentException("There should be join keys present from each stage");
+    }
+
+    List<Schema> prevSchemaList = null;
+    for (Map.Entry<String, List<String>> entry : perStageJoinKeys.entrySet()) {
+      ArrayList<Schema> schemaList = new ArrayList<>();
+      String stageName = entry.getKey();
+
+      Schema schema = inputSchemas.get(stageName);
+      if (schema == null) {
+        throw new IllegalArgumentException(String.format("Input schema for input stage %s can not be null", stageName));
+      }
+
+      for (String joinKey : entry.getValue()) {
+        Schema.Field field = schema.getField(joinKey);
+        if (field == null) {
+          throw new IllegalArgumentException(String.format("Join key field %s is not present in input of stage %s",
+              joinKey, stageName));
+        }
+        schemaList.add(field.getSchema().isNullable()? field.getSchema().getNonNullable(): field.getSchema());
+      }
+      if (prevSchemaList != null && !prevSchemaList.equals(schemaList)) {
+        throw new IllegalArgumentException(String.format("For stage %s, Schemas of joinKeys %s are expected to be: " +
+                "%s, but found: %s",
+            stageName, entry.getValue(), prevSchemaList.toString(),
+            schemaList.toString()));
+      }
+      prevSchemaList = schemaList;
+    }
+  }
+
+
+  @Override
+  public void configurePipeline(MultiInputPipelineConfigurer pipelineConfigurer) {
+    log.debug("Configuring pipeline");
+    MultiInputStageConfigurer stageConfigurer = pipelineConfigurer.getMultiInputStageConfigurer();
+    Map<String, Schema> inputSchemas = stageConfigurer.getInputSchemas();
+    init(inputSchemas);
+    //validate the input schema and get the output schema for it
+    stageConfigurer.setOutputSchema(getOutputSchema(conf.leftInput, inputSchemas));
+  }
+
+
+  @Override
+  public void prepareRun(BatchJoinerContext context) throws Exception {
+    log.debug("prepare run");
+    if (conf.getNumPartitions() != null) {
+      context.setNumPartitions(conf.getNumPartitions());
+    }
+    Map<String, Schema> inputSchemas = context.getInputSchemas();
+    init(inputSchemas);
+    Collection<OutputFieldInfo> outputFieldInfos = createOutputFieldInfos(conf.leftInput, inputSchemas);
+    Map<String, String> perStageTemporalJoinKeys = new HashMap<>();
+    assert inputSchemas.size() == 2;
+    inputSchemas.keySet().forEach((stage) -> {
+      if (conf.leftInput.equals(stage)) {
+        perStageTemporalJoinKeys.put(stage, conf.timeFieldLeft);
+      } else {
+        perStageTemporalJoinKeys.put(stage, conf.timeFieldRight);
+      }
+    });
+    context.record(createFieldOperations(outputFieldInfos, perStageTemporalJoinKeys, perStageJoinKeys));
+  }
+
+  /**
+   * Create the field operations from the provided OutputFieldInfo instances and join keys.
+   * For join we record several types of transformation; Join, Identity, and Rename.
+   * For each of these transformations, if the input field is directly coming from the schema
+   * of one of the stage, the field is added as {@code stage_name.field_name}. We keep track of fields
+   * outputted by operation (in {@code outputsSoFar set}, so that any operation uses that field as
+   * input later, we add it without the stage name.
+   * <p>
+   * Join transform operation is added with join keys as input tagged with the stage name, and join keys
+   * without stage name as output.
+   * <p>
+   * For other fields which are not renamed in join, Identity transform is added, while for fields which
+   * are renamed Rename transform is added.
+   *
+   * @param outputFieldInfos collection of output fields along with information such as stage name, alias
+   * @param perStageJoinKeys join keys
+   * @param perStageTemporalJoinKeys
+   * @return List of field operations
+   */
+  @VisibleForTesting
+  public static List<FieldOperation> createFieldOperations(Collection<OutputFieldInfo> outputFieldInfos,
+                                                           Map<String, String> perStageTemporalJoinKeys, Map<String, List<String>> perStageJoinKeys) {
+    LinkedList<FieldOperation> operations = new LinkedList<>();
+
+    // Add temporal join operations
+    List<String> temporalJoinInputs = new ArrayList<>();
+    Set<String> temporalJoinOutputs = new LinkedHashSet<>();
+    for (Map.Entry<String, String> joinKey : perStageTemporalJoinKeys.entrySet()) {
+      temporalJoinInputs.add(joinKey.getKey() + "." + joinKey.getValue());
+      temporalJoinOutputs.add(joinKey.getValue());
+    }
+    FieldOperation temporalJoinOperation = new FieldTransformOperation("TemporalJoin",
+        TEMPORAL_JOIN_OPERATION_DESCRIPTION, temporalJoinInputs, new ArrayList<>(temporalJoinOutputs));
+    operations.add(temporalJoinOperation);
+
+
+    // Add optional exact JOIN operations
+    List<String> joinInputs = new ArrayList<>();
+    Set<String> joinOutputs = new LinkedHashSet<>();
+    for (Map.Entry<String, List<String>> joinKey : perStageJoinKeys.entrySet()) {
+      for (String field : joinKey.getValue()) {
+        joinInputs.add(joinKey.getKey() + "." + field);
+        joinOutputs.add(field);
+      }
+    }
+    FieldOperation joinOperation = new FieldTransformOperation("Join", JOIN_OPERATION_DESCRIPTION, joinInputs,
+        new ArrayList<>(joinOutputs));
+    operations.add(joinOperation);
+
+
+    Set<String> outputsSoFar = new HashSet<>(joinOutputs);
+
+    for (OutputFieldInfo outputFieldInfo : outputFieldInfos) {
+      // input field name for the operation will come in from schema if its not outputted so far
+      String stagedInputField = outputsSoFar.contains(outputFieldInfo.inputFieldName) ?
+          outputFieldInfo.inputFieldName : outputFieldInfo.stageName + "." + outputFieldInfo.inputFieldName;
+
+      if (outputFieldInfo.name.equals(outputFieldInfo.inputFieldName)) {
+        // Record identity transform
+
+        if (perStageTemporalJoinKeys.get(outputFieldInfo.stageName).contains(outputFieldInfo.inputFieldName)
+            || (perStageJoinKeys.get(outputFieldInfo.stageName) != null
+            && perStageJoinKeys.get(outputFieldInfo.stageName).contains(outputFieldInfo.inputFieldName))) {
+          // if the field is part of join key no need to emit the identity transform as it is already taken care
+          // by join
+          continue;
+        }
+
+        String operationName = String.format("Identity %s", stagedInputField);
+        FieldOperation identity = new FieldTransformOperation(operationName, IDENTITY_OPERATION_DESCRIPTION,
+            Collections.singletonList(stagedInputField),
+            outputFieldInfo.name);
+        operations.add(identity);
+        continue;
+      }
+
+      String operationName = String.format("Rename %s", stagedInputField);
+
+      FieldOperation transform = new FieldTransformOperation(operationName, RENAME_OPERATION_DESCRIPTION,
+          Collections.singletonList(stagedInputField),
+          outputFieldInfo.name);
+      operations.add(transform);
+    }
+
+    return operations;
+  }
+
+  Schema getOutputSchema(String leftInput, Map<String, Schema> inputSchemas) {
+    return Schema.recordOf("join.output", getOutputFields(createOutputFieldInfos(leftInput, inputSchemas)));
+  }
+
+  private List<Schema.Field> getOutputFields(Collection<OutputFieldInfo> fieldsInfo) {
+    List<Schema.Field> outputFields = new ArrayList<>();
+    for (OutputFieldInfo fieldInfo : fieldsInfo) {
+      outputFields.add(fieldInfo.getField());
+    }
+    return outputFields;
+  }
+
+
+  @Override
+  public JavaRDD<StructuredRecord> join(SparkExecutionPluginContext context, Map<String, JavaRDD<?>> inputs) throws Exception {
+
+
+    StageInfo leftStageInfo = null;
+    StageInfo rightStageInfo = null;
+
+    // 1 - get stage info
+
+    for (Map.Entry<String, Schema> entry : inputSchemas.entrySet()) {
+      String stageName = entry.getKey();
+      Schema inputSchema = entry.getValue();
+      Map<String, String> colToAlias = perStageSelectedFields.row(stageName);
+      Map<String, String> joinKeyToAlias = getKeyToAlias(stageName, perStageJoinKeys);
+      JavaRDD<StructuredRecord> rdd = (JavaRDD<StructuredRecord>) inputs.get(stageName);
+      if (log.isDebugEnabled()) {
+        log.debug("Count for stage {}: {}", stageName, rdd.count());
+      }
+      if (conf.leftInput.equals(stageName)) {
+        leftStageInfo = new StageInfo(stageName, rdd, inputSchema, conf.timeFieldLeft, colToAlias, joinKeyToAlias);
+
+      } else {
+        rightStageInfo = new StageInfo(stageName, rdd, inputSchema, conf.timeFieldRight, colToAlias, joinKeyToAlias);
+      }
+    }
+
+    assert leftStageInfo != null && rightStageInfo != null;
+
+
+    // 1 - transform inputs to time series with target schema
+    TimeSeriesRDD leftTimeSeriesRDD = asTimeSeriesRDD((JavaRDD<StructuredRecord>) leftStageInfo
+        .rdd.map(leftStageInfo.getTransformInput()), leftStageInfo.getTransformedSchema(), false);
+    TimeSeriesRDD rightTimeSeriesRDD = asTimeSeriesRDD((JavaRDD<StructuredRecord>) rightStageInfo
+        .rdd.map(rightStageInfo.getTransformInput()), rightStageInfo.getTransformedSchema(), true);
+
+    // 2 - temporal join
+    Seq<String> keys = JavaConverters.asScalaIteratorConverter(leftStageInfo.keyToAlias.values().iterator()).asScala().toSeq();
+
+    TimeSeriesRDD joinedTimeSeriesRDD = leftTimeSeriesRDD.leftJoin(rightTimeSeriesRDD, conf.tolerance, keys, "", "");
+
+
+    log.debug("resulting schema for joinedTimeSeriesRDD: {}",joinedTimeSeriesRDD.schema());
+
+
+    // 3 - transform to final format
+    JavaRDD<StructuredRecord> result = (JavaRDD<StructuredRecord>) joinedTimeSeriesRDD.rdd().toJavaRDD()
+        .map(new RowToStructuredRecordFunction(outputSchema));
+    if (log.isDebugEnabled()) {
+      log.debug("result count: {}",result.count());
+    }
+    return result;
+
+  }
+
+  private static Map<String, String> getKeyToAlias(String stageName, Map<String, List<String>> perStageJoinKeys) {
+    List<String> joinKeys = perStageJoinKeys.get(stageName);
+    Map<String, String> joinKeyToAlias = new HashMap<>();
+    if (joinKeys == null) {
+      return joinKeyToAlias;
+    }
+    int i=0;
+    for (String key : joinKeys) {
+      String alias = JOIN_KEY_ALIAS + i;
+      joinKeyToAlias.put(key, alias);
+      i++;
+    }
+    return joinKeyToAlias;
+  }
+
+
+  private static class StageInfo implements Externalizable {
+    private String stageName;
+    private JavaRDD<StructuredRecord> rdd;
+    private Schema inputSchema;
+    private String timeField;
+    private Map<String, String> colToAlias;
+    private Map<String, String> keyToAlias;
+
+    //for serialization only
+    public StageInfo() {
+    }
+
+    public StageInfo(String stageName, JavaRDD<StructuredRecord> rdd, Schema inputSchema, String timeField, Map<String, String> colToAlias, Map<String, String> keyToAlias) {
+      Preconditions.checkNotNull(stageName);
+      Preconditions.checkNotNull(rdd);
+      Preconditions.checkNotNull(inputSchema);
+      Preconditions.checkNotNull(timeField);
+      Preconditions.checkNotNull(colToAlias);
+      Preconditions.checkNotNull(keyToAlias);
+
+      this.stageName = stageName;
+      this.rdd = rdd;
+      this.inputSchema = inputSchema;
+      this.timeField = timeField;
+      this.colToAlias = colToAlias;
+      this.keyToAlias = keyToAlias;
+
+      transformInput = new TransformInput();
+    }
+
+
+    private Schema getTransformedSchema() {
+
+      List<Schema.Field> fields = new ArrayList<>();
+
+      inputSchema.getFields().forEach(field -> {
+        String alias = colToAlias.get(field.getName());
+        if (alias != null) {
+          fields.add(Schema.Field.of(alias, field.getSchema()));
+        }
+      });
+
+      fields.add(Schema.Field.of(TIMEFIELD_ALIAS, inputSchema.getField(timeField).getSchema()));
+
+      keyToAlias.forEach((key,alias) ->{
+        fields.add(Schema.Field.of(alias, inputSchema.getField(key).getSchema()));
+      });
+
+      return Schema.recordOf(stageName+"-transformed", fields);
+
+    }
+
+
+    private class TransformInput implements Function<StructuredRecord, StructuredRecord> {
+
+      private final Schema transformedSchema = getTransformedSchema();
+
+      @Override
+      public StructuredRecord call(StructuredRecord record) throws Exception {
+        log.trace("called with {}", record.toString());
+        StructuredRecord.Builder builder = StructuredRecord.builder(transformedSchema);
+        inputSchema.getFields().stream().map(Schema.Field::getName).forEach(name -> {
+          String alias = colToAlias.get(name);
+          if (alias != null) {
+            builder.set(alias, record.get(name));
+          }
+        });
+        builder.set(TIMEFIELD_ALIAS,record.get(timeField));
+        keyToAlias.forEach((key, alias)-> {
+          builder.set(alias, record.get(key));
+        });
+        return builder.build();
+      }
+    }
+
+    private transient TransformInput transformInput;
+
+    private TransformInput getTransformInput() {
+      return transformInput;
+    }
+
+    @Override
+    public void writeExternal(ObjectOutput out) throws IOException {
+      out.writeObject(stageName);
+      out.writeObject(rdd);
+      out.writeObject(inputSchema);
+      out.writeObject(timeField);
+      out.writeObject(colToAlias);
+      out.writeObject(keyToAlias);
+    }
+
+    @SuppressWarnings("unchecked")
+    @Override
+    public void readExternal(ObjectInput in) throws IOException, ClassNotFoundException {
+      stageName = (String) in.readObject();
+      rdd = (JavaRDD<StructuredRecord>) in.readObject();
+      inputSchema = (Schema) in.readObject();
+      timeField = (String) in.readObject();
+      colToAlias = (Map<String, String>) in.readObject();
+      keyToAlias = (Map<String, String>)  in.readObject();
+
+      transformInput = new TransformInput();
+    }
+  }
+
+  @Path("outputSchema")
+  @VisibleForTesting
+  public Schema getOutputSchema(GetSchemaRequest request) {
+    validateJoinKeySchemas(request.inputSchemas, request.getPerStageJoinKeys());
+    perStageSelectedFields = request.getPerStageSelectedFields();
+    duplicateFields = ArrayListMultimap.create();
+    return getOutputSchema(request.leftInput, request.inputSchemas);
+  }
+
+
+  /**
+   * Endpoint request for output schema.
+   */
+  public static class GetSchemaRequest extends TemporalJoinerConfig {
+    public Map<String, Schema> inputSchemas;
+  }
+
+
+  private TimeSeriesRDD asTimeSeriesRDD(JavaRDD<StructuredRecord> rdd, Schema schema, boolean forceNullable) {
+    StructType structType = asStructType(schema, forceNullable);
+
+    JavaRDD<Row> rowRDD = (JavaRDD<Row>) rdd.map(new StruturedrecordToRowfunction(structType));
+
+
+    // TODO expose isSorted and possibily timeUnit as plugin parameters
+    return TimeSeriesRDDUtils.fromRDD(rowRDD.rdd(), structType, false, TimeUnit.MILLISECONDS, TIMEFIELD_ALIAS);
+  }
+
+  private static StructType asStructType(Schema schema, boolean forceNullable) {
+    List<StructField> structFields = new ArrayList<>();
+    schema.getFields().forEach((field) -> {
+      Schema fieldSchema = field.getSchema();
+      boolean nullable = fieldSchema.isNullable();
+      fieldSchema = nullable? fieldSchema.getNonNullable() : fieldSchema;
+      if (log.isDebugEnabled()) {
+        log.debug("name: {} type: {} nullable: {}", field.getName(), fieldSchema.getType(), nullable);
+      }
+      // force nullable?
+      nullable = forceNullable || nullable;
+      structFields.add(new StructField(field.getName(), convert(fieldSchema.getType()), nullable, Metadata.empty()));
+    });
+
+    return new StructType(structFields.toArray(new StructField[0]));
+  }
+
+  private <T> T getOrElse(T v, T dft) {
+    if (v instanceof String) {
+      v = StringUtils.isEmpty((String) v) ? null : v;
+    }
+    return v == null ? dft : v;
+  }
+
+  private static DataType convert(Schema.Type type) {
+    switch (type) {
+      case BYTES:
+        return DataTypes.BinaryType;
+      case BOOLEAN:
+        return DataTypes.BooleanType;
+      case INT:
+        return DataTypes.IntegerType;
+      case LONG:
+        return DataTypes.LongType;
+      case FLOAT:
+        return DataTypes.FloatType;
+      case DOUBLE:
+        return DataTypes.DoubleType;
+      case STRING:
+        return DataTypes.StringType;
+      default:
+        throw new IllegalArgumentException(String.format("Don't know how to convert %s to spark DataType", type));
+    }
+  }
+
+
+  private static class StruturedrecordToRowfunction implements Function<StructuredRecord, Row> {
+
+    private final StructType structType;
+
+
+    public StruturedrecordToRowfunction(StructType structType) {
+      this.structType = structType;
+    }
+
+    @Override
+    public Row call(StructuredRecord v1) throws Exception {
+
+      log.trace("v1: {}", v1);
+
+      List<Object> values = new ArrayList<>(structType.fields().length);
+
+      for (StructField field : structType.fields()) {
+        values.add((v1.get(field.name())));
+      }
+      return TimeSeriesRDDUtils.toRow(values,structType);
+    }
+  }
+
+  private static class RowToStructuredRecordFunction implements Function<Row, StructuredRecord> {
+
+    private final Schema schema;
+
+    public RowToStructuredRecordFunction(Schema schema) {
+      this.schema = schema;
+    }
+
+    @Override
+    public StructuredRecord call(Row row) throws Exception {
+      log.trace("row: {}", row);
+      StructuredRecord.Builder builder = StructuredRecord.builder(schema);
+      // only fields from target schema are kept, so all synthetic fields beginning with $$ are purposely forgotten
+      schema.getFields().forEach((field) -> {
+        builder.set(field.getName(), row.getAs(flintName(field)));
+      });
+      return builder.build();
+    }
+
+    private String flintName(Schema.Field field) {
+      String name = field.getName();
+      if (!(name.startsWith("_"))) {
+        name = "_"+name;
+      }
+      return name;
+    }
+  }
+
+
+  private Collection<OutputFieldInfo> createOutputFieldInfos(String leftInput, Map<String, Schema> inputSchemas) {
+    validateLeftInput(leftInput, inputSchemas);
+
+    // stage name to input schema
+    Map<String, Schema> inputs = new HashMap<>(inputSchemas);
+    // Selected Field name to output field info
+    Map<String, OutputFieldInfo> outputFieldInfo = new LinkedHashMap<>();
+    List<String> duplicateAliases = new ArrayList<>();
+
+    // order of fields in output schema will be same as order of selectedFields
+    Set<Table.Cell<String, String, String>> rows = perStageSelectedFields.cellSet();
+    for (Table.Cell<String, String, String> row : rows) {
+      String stageName = row.getRowKey();
+      String inputFieldName = row.getColumnKey();
+      String alias = row.getValue();
+      Schema inputSchema = inputs.get(stageName);
+
+      if (inputSchema == null) {
+        throw new IllegalArgumentException(String.format("Input schema for input stage %s can not be null", stageName));
+      }
+
+      if (outputFieldInfo.containsKey(alias)) {
+        OutputFieldInfo outInfo = outputFieldInfo.get(alias);
+        if (duplicateAliases.add(alias)) {
+          duplicateFields.put(outInfo.getStageName(), outInfo.getInputFieldName());
+        }
+        duplicateFields.put(stageName, inputFieldName);
+        continue;
+      }
+
+      Schema.Field inputField = inputSchema.getField(inputFieldName);
+      if (inputField == null) {
+        throw new IllegalArgumentException(String.format(
+            "Invalid field: %s of stage '%s' does not exist in input schema %s.",
+            inputFieldName, stageName, inputSchema));
+      }
+      // set nullable fields for non-required inputs
+      if (leftInput.equals(stageName) || inputField.getSchema().isNullable()) {
+        outputFieldInfo.put(alias, new OutputFieldInfo(alias, stageName, inputFieldName,
+            Schema.Field.of(alias, inputField.getSchema())));
+      } else {
+        outputFieldInfo.put(alias, new OutputFieldInfo(alias, stageName, inputFieldName,
+            Schema.Field.of(alias,
+                Schema.nullableOf(inputField.getSchema()))));
+      }
+    }
+
+    if (!duplicateFields.isEmpty()) {
+      throw new IllegalArgumentException(String.format("Output schema must not have any duplicate field names, but " +
+              "found duplicate fields: %s for aliases: %s", duplicateFields,
+          duplicateAliases));
+    }
+
+    return outputFieldInfo.values();
+  }
+
+  private void validateLeftInput(String leftInput, Map<String, Schema> inputSchemas) throws IllegalArgumentException {
+
+    if (!inputSchemas.containsKey(leftInput)) {
+      throw new IllegalArgumentException(String.format("Provided left input %s is not an input stage name.",
+          leftInput));
+    }
+  }
+
+
+  /**
+   * Class to hold information about output fields
+   */
+  @VisibleForTesting
+  static class OutputFieldInfo {
+    private String name;
+    private String stageName;
+    private String inputFieldName;
+    private Schema.Field field;
+
+    OutputFieldInfo(String name, String stageName, String inputFieldName, Schema.Field field) {
+      this.name = name;
+      this.stageName = stageName;
+      this.inputFieldName = inputFieldName;
+      this.field = field;
+    }
+
+    public String getName() {
+      return name;
+    }
+
+    public void setName(String name) {
+      this.name = name;
+    }
+
+    public String getStageName() {
+      return stageName;
+    }
+
+    public void setStageName(String stageName) {
+      this.stageName = stageName;
+    }
+
+    public String getInputFieldName() {
+      return inputFieldName;
+    }
+
+    public void setInputFieldName(String inputFieldName) {
+      this.inputFieldName = inputFieldName;
+    }
+
+    public Schema.Field getField() {
+      return field;
+    }
+
+    public void setField(Schema.Field field) {
+      this.field = field;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+      if (this == o) {
+        return true;
+      }
+      if (o == null || getClass() != o.getClass()) {
+        return false;
+      }
+
+      OutputFieldInfo that = (OutputFieldInfo) o;
+
+      if (!name.equals(that.name)) {
+        return false;
+      }
+      if (!stageName.equals(that.stageName)) {
+        return false;
+      }
+      if (!inputFieldName.equals(that.inputFieldName)) {
+        return false;
+      }
+      return field.equals(that.field);
+    }
+
+    @Override
+    public int hashCode() {
+      int result = name.hashCode();
+      result = 31 * result + stageName.hashCode();
+      result = 31 * result + inputFieldName.hashCode();
+      result = 31 * result + field.hashCode();
+      return result;
+    }
+
+    @Override
+    public String toString() {
+      return "OutputFieldInfo{" +
+          "name='" + name + '\'' +
+          ", stageName='" + stageName + '\'' +
+          ", inputFieldName='" + inputFieldName + '\'' +
+          ", field=" + field +
+          '}';
+    }
+  }
+
+
+}

--- a/flint-plugins/src/main/java/co/cask/hydrator/plugin/flint/TemporalJoinerConfig.java
+++ b/flint-plugins/src/main/java/co/cask/hydrator/plugin/flint/TemporalJoinerConfig.java
@@ -1,0 +1,197 @@
+package co.cask.hydrator.plugin.flint;
+
+import co.cask.cdap.api.annotation.Description;
+import co.cask.cdap.api.dataset.lib.KeyValue;
+import co.cask.cdap.api.plugin.PluginConfig;
+import co.cask.hydrator.common.KeyValueListParser;
+import com.google.common.base.Splitter;
+import com.google.common.base.Strings;
+import com.google.common.collect.ImmutableSet;
+import com.google.common.collect.ImmutableTable;
+import com.google.common.collect.Iterables;
+import com.google.common.collect.Table;
+
+import javax.annotation.Nullable;
+import java.util.*;
+
+public class TemporalJoinerConfig extends PluginConfig {
+    private static final String NUM_PARTITIONS_DESC = "Number of partitions to use when joining. " +
+            "If not specified, the execution framework will decide how many to use.";
+    private static final String JOIN_KEY_DESC = "Optional list of join keys to perform exact join operation. " +
+            "If non-empty, the most recent row from the " +
+            "right that shares the same keys with the current row from the left will be joined. The list is " +
+            "separated by '&'. Join key from each input stage will be prefixed with '<stageName>.' And the " +
+            "relation among join keys from different inputs is represented by '='. For example: " +
+            "items.c_id=customers.customer_id&items.c_name=customers.customer_name means the join key is a composite key" +
+            " of customer id and customer name from customers and items input stages and join will add " +
+            " the most recent info on customers to the items that were sold to thoses customers.";
+    private static final String SELECTED_FIELDS = "Comma-separated list of fields to be selected and renamed " +
+            "in join output from each input stage. Each selected input field name needs to be present in the output must be " +
+            "prefixed with '<input_stage_name>'. The syntax for specifying alias for each selected field is similar to sql. " +
+            "For example: customers.id as customer_id, customer.name as customer_name, item.id as item_id, " +
+            "<stageName>.inputFieldName as alias. The output will have same order of fields as selected in selectedFields." +
+            "There must not be any duplicate fields in output.";
+    private static final String LEFT_INPUT_DESC = "The stage that will be used as the left part of the (left outer) join. " +
+            "This is the mandatory input part of the join.";
+    public static final String TIME_FIELD_LEFT_DESC = "Name of the time field for the left input source. " +
+            "Defaults to 'time'";
+    public static final String TIME_FIELD_RIGHT_DESC = "Name of the time field for the right input source. " +
+            "Defaults to 'time'";
+    public static final String TOLERANCE_DESC = "The most recent row from the right will only be appended " +
+            "if it was within the specified time of the row from the left. " +
+            "The default tolerance is 'Ons' which provides the exact left-join. " +
+            "Examples of possible values are '10µs', '1ms', '2s', '5m', '5 min', '10h' or '10 hours', '25d' or '25 days' etc. " +
+            "See 'scala.concurrent.Duration' for details";
+
+
+    @Nullable
+    @Description(NUM_PARTITIONS_DESC)
+    protected Integer numPartitions;
+
+    @Nullable
+    @Description(JOIN_KEY_DESC)
+    protected String joinKeys;
+
+
+    @Description(TIME_FIELD_LEFT_DESC)
+    @Nullable
+    protected String timeFieldLeft;
+
+    @Description(TIME_FIELD_RIGHT_DESC)
+    @Nullable
+    protected String timeFieldRight;
+
+    @Description(TOLERANCE_DESC)
+    @Nullable
+    protected String tolerance;
+
+    @Description(SELECTED_FIELDS)
+    protected String selectedFields;
+
+    @Nullable
+    @Description(LEFT_INPUT_DESC)
+    protected String leftInput;
+
+    public TemporalJoinerConfig(String joinKeys, String selectedFields, @Nullable String leftInput) {
+        this.joinKeys = joinKeys;
+        this.selectedFields = selectedFields;
+        this.leftInput = leftInput;
+    }
+
+    public TemporalJoinerConfig() {
+        selectedFields = "";
+        leftInput = "";
+        tolerance = "0ns";
+    }
+
+    @Nullable
+    public Integer getNumPartitions() {
+        return numPartitions;
+    }
+
+    public String getSelectedFields() {
+        return selectedFields;
+    }
+
+    public String getJoinKeys() {
+        return joinKeys;
+    }
+
+    @Nullable
+    public String getLeftInput() {
+        return leftInput;
+    }
+
+    @Nullable
+    public String getTimeFieldLeft() {
+        return timeFieldLeft;
+    }
+
+    @Nullable
+    public String getTimeFieldRight() {
+        return timeFieldRight;
+    }
+
+    @Nullable
+    public String getTolerance() {
+        return tolerance;
+    }
+
+    Map<String, List<String>> getPerStageJoinKeys() {
+        Map<String, List<String>> stageToKey = new HashMap<>();
+
+        // ok, exact join keys are optional after all
+        if (Strings.isNullOrEmpty(joinKeys)) {
+            return stageToKey;
+        }
+
+        Iterable<String> multipleJoinKeys = Splitter.on('&').trimResults().omitEmptyStrings().split(joinKeys);
+
+        if (Iterables.isEmpty(multipleJoinKeys)) {
+            throw new IllegalArgumentException("Join keys can not be empty.");
+        }
+
+        int numJoinKeys = 0;
+        for (String singleJoinKey : multipleJoinKeys) {
+            KeyValueListParser kvParser = new KeyValueListParser("\\s*=\\s*", "\\.");
+            Iterable<KeyValue<String, String>> keyValues = kvParser.parse(singleJoinKey);
+            if (numJoinKeys == 0) {
+                numJoinKeys = Iterables.size(keyValues);
+            } else if (numJoinKeys != Iterables.size(keyValues)) {
+                throw new IllegalArgumentException("There should be one join key from each of the stages. Please add join " +
+                        "keys for each stage.");
+            }
+            for (KeyValue<String, String> keyValue : keyValues) {
+                String stageName = keyValue.getKey();
+                String joinKey = keyValue.getValue();
+                if (!stageToKey.containsKey(stageName)) {
+                    stageToKey.put(stageName, new ArrayList<String>());
+                }
+                stageToKey.get(stageName).add(joinKey);
+            }
+        }
+        return stageToKey;
+    }
+
+    Table<String, String, String> getPerStageSelectedFields() {
+        // table to store <stageName, oldFieldName, alias>
+        ImmutableTable.Builder<String, String, String> tableBuilder = new ImmutableTable.Builder<>();
+
+        if (Strings.isNullOrEmpty(selectedFields)) {
+            throw new IllegalArgumentException("selectedFields can not be empty. Please provide at least 1 selectedFields");
+        }
+
+        for (String selectedField : Splitter.on(',').trimResults().omitEmptyStrings().split(selectedFields)) {
+            Iterable<String> stageOldNameAliasPair = Splitter.on(" as ").trimResults().omitEmptyStrings()
+                    .split(selectedField);
+            Iterable<String> stageOldNamePair = Splitter.on('.').trimResults().omitEmptyStrings().
+                    split(Iterables.get(stageOldNameAliasPair, 0));
+
+            if (Iterables.size(stageOldNamePair) != 2) {
+                throw new IllegalArgumentException(String.format("Invalid syntax. Selected Fields must be of syntax " +
+                                "<stageName>.<oldFieldName> as <alias>, but found %s",
+                        selectedField));
+            }
+
+            String stageName = Iterables.get(stageOldNamePair, 0);
+            String oldFieldName = Iterables.get(stageOldNamePair, 1);
+
+            // if alias is not present in selected fields, use original field name as alias
+            String alias = isAliasPresent(stageOldNameAliasPair) ? oldFieldName : Iterables.get(stageOldNameAliasPair, 1);
+            tableBuilder.put(stageName, oldFieldName, alias);
+        }
+        return tableBuilder.build();
+    }
+
+    private boolean isAliasPresent(Iterable<String> stageOldNameAliasPair) {
+        return Iterables.size(stageOldNameAliasPair) == 1;
+    }
+
+    Set<String> getInputs() {
+        if (!Strings.isNullOrEmpty(leftInput)) {
+            return ImmutableSet.copyOf(Splitter.on(',').trimResults().omitEmptyStrings().split(leftInput));
+        }
+        return ImmutableSet.of();
+    }
+
+}

--- a/flint-plugins/src/main/scala/co/cask/hydrator/plugin/flint/TimeSeriesRDDUtils.scala
+++ b/flint-plugins/src/main/scala/co/cask/hydrator/plugin/flint/TimeSeriesRDDUtils.scala
@@ -1,0 +1,36 @@
+package co.cask.hydrator.plugin.flint
+
+import java.util.concurrent.TimeUnit
+
+import com.twosigma.flint.timeseries.TimeSeriesRDD
+import org.apache.spark.rdd.RDD
+import org.apache.spark.sql.Row
+import org.apache.spark.sql.catalyst.expressions.{GenericRow, GenericRowWithSchema}
+import org.apache.spark.sql.types.StructType
+
+import collection.JavaConverters._
+
+
+
+object TimeSeriesRDDUtils {
+
+  def fromRDD(
+               rdd: RDD[Row],
+               schema: StructType,
+               isSorted: Boolean,
+               timeUnit: TimeUnit,
+               timeColumn: String
+             ): TimeSeriesRDD = {
+
+    TimeSeriesRDD.fromRDD(rdd, schema)(isSorted, timeUnit, timeColumn)
+  }
+
+
+  def toRow(vals: java.util.List[Object], structType: StructType): Row = {
+
+    val seq = vals.asScala
+    new GenericRowWithSchema(seq.toArray[Any], structType)
+  }
+
+
+}

--- a/flint-plugins/src/test/java/co/cask/hydrator/plugin/flint/test/FlintPluginTest.java
+++ b/flint-plugins/src/test/java/co/cask/hydrator/plugin/flint/test/FlintPluginTest.java
@@ -1,0 +1,82 @@
+/*
+ * Copyright © 2016 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package co.cask.hydrator.plugin.flint.test;
+
+import co.cask.cdap.api.artifact.ArtifactRange;
+import co.cask.cdap.api.artifact.ArtifactSummary;
+import co.cask.cdap.api.artifact.ArtifactVersion;
+import co.cask.cdap.datapipeline.DataPipelineApp;
+import co.cask.cdap.datastreams.DataStreamsApp;
+import co.cask.cdap.etl.mock.test.HydratorTestBase;
+import co.cask.cdap.proto.id.ArtifactId;
+import co.cask.cdap.proto.id.NamespaceId;
+import co.cask.cdap.test.TestConfiguration;
+import com.google.common.collect.ImmutableSet;
+import org.junit.AfterClass;
+import org.junit.BeforeClass;
+import org.junit.ClassRule;
+import org.junit.rules.TemporaryFolder;
+
+import java.util.Set;
+
+/**
+ * Tests for Spark plugins.
+ */
+public class FlintPluginTest extends HydratorTestBase {
+
+  @ClassRule
+  public static final TestConfiguration CONFIG = new TestConfiguration("explore.enabled", false);
+
+  protected static final ArtifactId DATAPIPELINE_ARTIFACT_ID =
+    NamespaceId.DEFAULT.artifact("data-pipeline", "3.2.0");
+  protected static final ArtifactId DATASTREAMS_ARTIFACT_ID =
+    NamespaceId.DEFAULT.artifact("data-streams", "3.2.0");
+  protected static final ArtifactSummary DATASTREAMS_ARTIFACT = new ArtifactSummary("data-streams", "3.2.0");
+
+
+  @ClassRule
+  public static TemporaryFolder tmpFolder = new TemporaryFolder();
+
+
+  @BeforeClass
+  public static void setupTest() throws Exception {
+    // add the artifact for data pipeline app
+    setupBatchArtifacts(DATAPIPELINE_ARTIFACT_ID, DataPipelineApp.class);
+
+    setupStreamingArtifacts(DATASTREAMS_ARTIFACT_ID, DataStreamsApp.class);
+
+    // add artifact for spark plugins
+    Set<ArtifactRange> parents = ImmutableSet.of(
+      new ArtifactRange(NamespaceId.DEFAULT.getNamespace(), DATAPIPELINE_ARTIFACT_ID.getArtifact(),
+                        new ArtifactVersion(DATAPIPELINE_ARTIFACT_ID.getVersion()), true,
+                        new ArtifactVersion(DATAPIPELINE_ARTIFACT_ID.getVersion()), true),
+      new ArtifactRange(NamespaceId.DEFAULT.getNamespace(), DATASTREAMS_ARTIFACT_ID.getArtifact(),
+                        new ArtifactVersion(DATASTREAMS_ARTIFACT_ID.getVersion()), true,
+                        new ArtifactVersion(DATASTREAMS_ARTIFACT_ID.getVersion()), true)
+    );
+/*
+    addPluginArtifact(NamespaceId.DEFAULT.artifact("spark-plugins", "1.0.0"), parents,
+                      TwitterStreamingSource.class, FileStreamingSource.class,
+                      HTTPPollerSource.class, HTTPPollConfig.class);
+*/
+  }
+
+  @AfterClass
+  public static void cleanup() throws Exception {
+  }
+
+}

--- a/flint-plugins/widgets/TemporalJoiner-sparkjoiner.json
+++ b/flint-plugins/widgets/TemporalJoiner-sparkjoiner.json
@@ -1,0 +1,63 @@
+{
+  "metadata": {
+    "spec-version": "1.3"
+  },
+  "inputs": {
+    "multipleInputs": true
+  },
+  "configuration-groups": [
+    {
+      "label": "Join",
+      "properties": [
+        {
+          "widget-type": "sql-select-fields",
+          "label": "Fields",
+          "name": "selectedFields",
+          "description": "List of fields to be selected and/or renamed in the Joiner output from each stages. There must not be a duplicate fields in the output."
+        },
+        {
+          "widget-type": "sql-conditions",
+          "label": "Exact Join Condition",
+          "name": "joinKeys",
+          "description": "List of join keys to perform exact part of join operation."
+        },
+        {
+          "widget-type": "textbox",
+          "label": "Left input stage",
+          "name": "leftInput"
+        },
+        {
+          "widget-type": "textbox",
+          "label": "Time field left",
+          "name": "timeFieldLeft"
+        },
+        {
+          "widget-type": "textbox",
+          "label": "Time field right",
+          "name": "timeFieldRight"
+        },
+        {
+          "widget-type": "textbox",
+          "label": "Max time interval",
+          "name": "tolerance"
+        },
+        {
+          "widget-type": "textbox",
+          "label": "Number of Partitions",
+          "name": "numPartitions",
+          "plugin-function": {
+            "method": "POST",
+            "label": "Generate Schema",
+            "widget": "outputSchema",
+            "output-property": "schema",
+            "plugin-method": "outputSchema",
+            "position": "bottom",
+            "multiple-inputs": true,
+            "button-class": "btn-hydrator"
+          }
+        }
+      ]
+    }
+  ],
+  "outputs": []
+}

--- a/pom.xml
+++ b/pom.xml
@@ -45,6 +45,7 @@
     <module>kafka-plugins</module>
     <module>amazon-s3-plugins</module>
     <module>condition-plugins</module>
+    <module>flint-plugins</module>
   </modules>
 
   <licenses>
@@ -64,6 +65,58 @@
       <organizationUrl>http://www.cdap.io</organizationUrl>
     </developer>
   </developers>
+
+
+    <repositories>
+        <repository>
+            <id>apache</id>
+            <url>https://repository.apache.org/content/repositories/public/</url>
+            <releases>
+                <enabled>true</enabled>
+                <updatePolicy>daily</updatePolicy>
+                <checksumPolicy>fail</checksumPolicy>
+            </releases>
+            <snapshots>
+                <enabled>false</enabled>
+            </snapshots>
+        </repository>
+        <repository>
+            <id>hortonworks</id>
+            <name>hortonworks</name>
+            <url>http://repo.hortonworks.com/content/repositories/releases/</url>
+            <layout>default</layout>
+            <releases>
+                <enabled>true</enabled>
+            </releases>
+            <snapshots>
+                <enabled>false</enabled>
+            </snapshots>
+        </repository>
+        <repository>
+            <id>sonatype</id>
+            <url>https://oss.sonatype.org/content/repositories/snapshots/</url>
+            <releases>
+                <enabled>false</enabled>
+            </releases>
+            <snapshots>
+                <enabled>true</enabled>
+                <updatePolicy>always</updatePolicy>
+                <checksumPolicy>fail</checksumPolicy>
+            </snapshots>
+        </repository>
+        <repository>
+            <id>snapshot</id>
+            <url>https://repository.apache.org/content/repositories/snapshots/</url>
+            <releases>
+                <enabled>false</enabled>
+            </releases>
+            <snapshots>
+                <enabled>true</enabled>
+                <updatePolicy>always</updatePolicy>
+                <checksumPolicy>fail</checksumPolicy>
+            </snapshots>
+        </repository>
+    </repositories>
 
   <scm>
     <connection>scm:git:https://github.com/caskdata/hydrator-plugins.git</connection>
@@ -714,7 +767,7 @@
       <plugin>
         <groupId>org.apache.rat</groupId>
         <artifactId>apache-rat-plugin</artifactId>
-        <version>0.10</version>
+        <version>0.11</version>
         <dependencies>
           <dependency>
             <groupId>org.apache.maven.doxia</groupId>


### PR DESCRIPTION
Provide an implementation of a temporal joiner as described in CDAP-15910. 
The implementation is based on flint timeseries spark 2 library. 
It allows one to join two datasets (in batch or real time) on a temporal column (of long or timestamp CDAP type) and, optionally, one or more exact match join keys as in the original joiner plugin.
Prerequisites for the CDAP plateform :
- implementation of SparkJoiner plugin (PR already raised)
- spark 2.3 or 2.4. This is OK for the Guavus 5.1.2.215+ branch of CDAP plateform but is not yet compliant with current cdap.io branch